### PR TITLE
update node types to use exact version

### DIFF
--- a/src/kong-adapter/package.json
+++ b/src/kong-adapter/package.json
@@ -24,7 +24,7 @@
     "kongversion": "0.14.1"
   },
   "devDependencies": {
-    "@types/node": "^10.11.3",
+    "@types/node": "10.11.3",
     "typescript": "3.4.1"
   }
 }


### PR DESCRIPTION
Updating node types to use exact version in order to prevent build failures.
version 10.17.29 was recently published 18 hours ago which is causing problems