### PR TITLE
Hideing Cortellis apis' related Cortellis UI from apis page for all user

### DIFF
--- a/src/ui/views/apis.pug
+++ b/src/ui/views/apis.pug
@@ -92,9 +92,12 @@ block content
                     +apiDef(filteredApiList[i+1])
                   if (i+2) < filteredApiList.length
                     +apiDef(filteredApiList[i+2])
-          else if authUser && (authUser.admin !== true && authUser.authenticated_scope.includes('wicked:api-cortellis-user'))
-              - const excludedApiIds = ["cortellis-np-drugs-api", "cortellis-np-companies-api", "cortellis-np-sources-api"];
-              - const filteredApiList = apilist.filter(api => !excludedApiIds.includes(api.id));
+          //- //Hideing All api listed in glob.cortellisUi.cortelliesApi.InvestigationalApi For {Admin}{superadmin}{appover}{publicUser}{authUser} requiredGroup which empty
+          else if authUser && (authUser.admin !== true && authUser.authenticated_scope.includes('wicked:')) || authUser !== true
+              - const apiDataString = JSON.stringify(glob.cortellisUi.cortelliesApi.InvestigationalApi);
+              - const apiData = JSON.parse(apiDataString);
+              - const apiIDs = apiData.map(obj => Object.values(obj));
+              - const filteredApiList = apilist.filter(api => !apiIDs.some(item => item.includes(api.id)));
               each api, i in filteredApiList
                 if i % 3 === 0
                   div(class="row")


### PR DESCRIPTION
### Adding check for Hiding All api listed in glob.cortellisUi.cortelliesApi.InvestigationalApi, for requiredGroup which empty

1. For {Admin}
2. {superadmin}
3. {appover}
4. {publicUser}
5. {authUser}
 dynamically fetch api Id here from cortellisui.json file