### PR TITLE
Render the cortellis api document for public user and Skus null (snaoshot)

### DIFF
--- a/src/ui/routes/apis.js
+++ b/src/ui/routes/apis.js
@@ -115,7 +115,7 @@ router.get('/:api', function (req, res, next) {
     // And possibly also the Auth Server of the API:
     // /auth-servers/:serverId
 
-    const apiId = req.params.api;
+    let apiId = req.params.api;
     const loggedInUserId = utils.getLoggedInUserId(req);
 
     async.parallel({

--- a/src/ui/routes/apis.js
+++ b/src/ui/routes/apis.js
@@ -183,13 +183,13 @@ router.get('/:api', function (req, res, next) {
             for (let i = 0; i < userInfo.applications.length; ++i)
                 appIds.push(userInfo.applications[i].id);
         }
-        let cortelliesapiSwap = [];
-        let reSwap = [];
-        let cortelliespiIdsSwap = req.app.portalGlobals.cortellisUi.cortelliesApi.InvestigationalApi;
-        cortelliespiIdsSwap.forEach(function (api) {
+        let cortelliesapiIdForSwap = []; //This will get apiId for Swaping the cortellis-api-collection subscriptions
+        let cortelliesOriginalApiId = []; // This will get original apiIds for Swaping with the cortellis-api-collection swagger URL
+        let cortelliesapiDocIds = req.app.portalGlobals.cortellisUi.cortelliesApi.InvestigationalApi;
+        cortelliesapiDocIds.forEach(function (api) {
             for (let key in api) {
                 if (api.hasOwnProperty(key)) {
-                    cortelliesapiSwap.push(api[key]);
+                    cortelliesapiIdForSwap.push(api[key]);
                 }}
         });
         // Note: callback and results are used all the time, but in the end, all's
@@ -197,9 +197,9 @@ router.get('/:api', function (req, res, next) {
         async.parallel({
             getSubs: function (callback) {
                 async.map(appIds, function (appId, callback) {
-                    for (let i = 0; i < cortelliesapiSwap.length; i++) {
-                        if (apiId === cortelliesapiSwap[i]) {
-                        reSwap.push(apiId)
+                    for (let i = 0; i < cortelliesapiIdForSwap.length; i++) {
+                        if (apiId === cortelliesapiIdForSwap[i]) {
+                        cortelliesOriginalApiId.push(apiId)
                         apiId = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
                         break;
                       }
@@ -330,18 +330,18 @@ router.get('/:api', function (req, res, next) {
 
             // See also views/models/api.json for how this looks
             let cortelliesapiIdValues = [];
-            let CortellisBundleApikey = [];
+            let cortellisBundleApikey = [];
+            let matchingValue = null;
             //check extracting apiId in json file in content
             // let cortellisMainApi = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
-            let cortelliespiIds = req.app.portalGlobals.cortellisUi.cortelliesApi.InvestigationalApi;
-                cortelliespiIds.forEach(function (api) {
-                    for (let key in api) {
-                        if (api.hasOwnProperty(key)) {
-                            cortelliesapiIdValues.push(api[key]);
-                        }}
-                });
+            let cortelliesApiIds = req.app.portalGlobals.cortellisUi.cortelliesApi.InvestigationalApi;
+            cortelliesApiIds.forEach(function (api) {
+                for (let key in api) {
+                if (api.hasOwnProperty(key)) {
+                    cortelliesapiIdValues.push(api[key]);
+                }}
+            });
             //check for only api ids json file in content
-            let matchingValue = null;
             for (let i = 0; i < cortelliesapiIdValues.length; i++) {
                 if (apiInfo.id.includes(cortelliesapiIdValues[i])) {
                     matchingValue = cortelliesapiIdValues[i];
@@ -349,14 +349,14 @@ router.get('/:api', function (req, res, next) {
                 }
             }
             if (matchingValue !== null){
-                let cortellisMainApi = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
+            let cortellisMainApi = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
             let hasapikey = true;
             if (hasapikey) {
                 // loop will only excetue for JSON FILE API IDS only 
                 apps.forEach(app => {
                     if (app.swaggerLink && app.swaggerLink.includes(cortellisMainApi) && app.subscriptionApproved === true) {
                         if(app.apiKey !== "none")
-                        CortellisBundleApikey.push(app.apiKey)
+                        cortellisBundleApikey.push(app.apiKey)
                     }
                 });
               }
@@ -451,7 +451,7 @@ router.get('/:api', function (req, res, next) {
                 else if (!utils.acceptJson(req)) {
                     if (genericSwaggerUrl.includes(req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId))
                     {
-                        genericSwaggerUrl = genericSwaggerUrl.replace(req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId, reSwap)
+                        genericSwaggerUrl = genericSwaggerUrl.replace(req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId, cortelliesOriginalApiId)
                     }
                     res.render('api', {
                         authUser: req.user,

--- a/src/ui/routes/apis.js
+++ b/src/ui/routes/apis.js
@@ -429,9 +429,9 @@ router.get('/:api', function (req, res, next) {
                     }
                 }
                 else if (!utils.acceptJson(req)) {
-                    if (genericSwaggerUrl.includes(req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId))
+                    if (genericSwaggerUrl.includes(cortellisMainApi))
                     {
-                        genericSwaggerUrl = genericSwaggerUrl.replace(req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId, cortelliesOriginalApiId)
+                        genericSwaggerUrl = genericSwaggerUrl.replace(cortellisMainApi, cortelliesOriginalApiId)
                     }
                     res.render('api', {
                         authUser: req.user,

--- a/src/ui/routes/apis.js
+++ b/src/ui/routes/apis.js
@@ -327,8 +327,32 @@ router.get('/:api', function (req, res, next) {
                     }
                 }
                 const customId = JSON.stringify(userInfo.customId)
-                const trueid = customId.split(":")
-                const sanitizedId = trueid.length > 1 ? trueid[1] : null;
+                let trueid, sanitizedId;
+                if (customId){
+                    trueid = customId.split(":")
+                    sanitizedId = trueid.length > 1 ? trueid[1] : null;
+                }
+                if ( customId === undefined || trueid === undefined  || sanitizedId === null ) {
+                    // Render the page directly without making the API request
+                    debug("I AM IF I AM GOING FIRST")
+                    res.render('cortellisApi', {
+                        authUser: req.user,
+                        glob: req.app.portalGlobals,
+                        route: '/apis/' + apiId,
+                        title: apiInfo.name,
+                        apiInfo: apiInfo,
+                        apiDesc: marked(apiDesc, markedOptions),
+                        applications: apps,
+                        apiPlans: plans,
+                        apiUris: apiUris,
+                        skusData: null, // Assuming skusData should be null in this case
+                        userInfo: userInfo,
+                        apiSubscriptions: apiSubscriptions,
+                        genericSwaggerUrl: genericSwaggerUrl,
+                        partnerOnly: partnerOnly
+                    });
+                }
+                else {
                 const trueId = sanitizedId.replace(/\"$/, '');
                 const apiKey = req.app.portalGlobals.network.clarivateapikey;
                 const kongProxyURl = req.app.portalGlobals.network.apiHost;
@@ -355,32 +379,28 @@ router.get('/:api', function (req, res, next) {
                       });
                     }
                   }, (err, results) => {
-                    if (err) {
-                      debug('An error occurred:', err);
-                      // Handle the error appropriately, e.g., return an error response
-                    } else {
-                      debug('Results:', results);
-                
-                      if (!utils.acceptJson(req)) {
-                        res.render('cortellisApi', {
-                          authUser: req.user,
-                          glob: req.app.portalGlobals,
-                          route: '/apis/' + apiId,
-                          title: apiInfo.name,
-                          apiInfo: apiInfo,
-                          apiDesc: marked(apiDesc, markedOptions),
-                          applications: apps,
-                          apiPlans: plans,
-                          apiUris: apiUris,
-                          skusData: responseData,
-                          userInfo: userInfo,
-                          apiSubscriptions: apiSubscriptions,
-                          genericSwaggerUrl: genericSwaggerUrl,
-                          partnerOnly: partnerOnly
+                        if (err && !utils.acceptJson(req)) {
+                        } else {
+                          debug('Results:', results);
+                          res.render('cortellisApi', {
+                            authUser: req.user,
+                            glob: req.app.portalGlobals,
+                            route: '/apis/' + apiId,
+                            title: apiInfo.name,
+                            apiInfo: apiInfo,
+                            apiDesc: marked(apiDesc, markedOptions),
+                            applications: apps,
+                            apiPlans: plans,
+                            apiUris: apiUris,
+                            skusData: responseData,
+                            userInfo: userInfo,
+                            apiSubscriptions: apiSubscriptions,
+                            genericSwaggerUrl: genericSwaggerUrl,
+                            partnerOnly: partnerOnly
                         });
-                      }
+                        }
+                      });
                     }
-                  });
                 }
             else if (!utils.acceptJson(req)) {
                 res.render('api', {

--- a/src/ui/routes/apis.js
+++ b/src/ui/routes/apis.js
@@ -186,6 +186,7 @@ router.get('/:api', function (req, res, next) {
         let cortelliesapiIdForSwap = []; //This will get apiId for Swaping the cortellis-api-collection subscriptions
         let cortelliesOriginalApiId = []; // This will get original apiIds for Swaping with the cortellis-api-collection swagger URL
         let cortelliesapiDocIds = req.app.portalGlobals.cortellisUi.cortelliesApi.InvestigationalApi;
+        let cortellisMainApi = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
         cortelliesapiDocIds.forEach(function (api) {
             for (let key in api) {
                 if (api.hasOwnProperty(key)) {
@@ -200,7 +201,7 @@ router.get('/:api', function (req, res, next) {
                     for (let i = 0; i < cortelliesapiIdForSwap.length; i++) {
                         if (apiId === cortelliesapiIdForSwap[i]) {
                         cortelliesOriginalApiId.push(apiId)
-                        apiId = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
+                        apiId = cortellisMainApi;
                         break;
                       }
                     }
@@ -328,40 +329,19 @@ router.get('/:api', function (req, res, next) {
             apiInfo.hasProtectedAuthMethods = hasProtectedMethods;
             apiInfo.hasSwaggerApplication = hasSwaggerApplication;
 
-            // See also views/models/api.json for how this looks
-            let cortelliesapiIdValues = [];
-            let cortellisBundleApikey = [];
-            let matchingValue = null;
-            //check extracting apiId in json file in content
-            // let cortellisMainApi = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
-            let cortelliesApiIds = req.app.portalGlobals.cortellisUi.cortelliesApi.InvestigationalApi;
-            cortelliesApiIds.forEach(function (api) {
-                for (let key in api) {
-                if (api.hasOwnProperty(key)) {
-                    cortelliesapiIdValues.push(api[key]);
-                }}
-            });
-            //check for only api ids json file in content
-            for (let i = 0; i < cortelliesapiIdValues.length; i++) {
-                if (apiInfo.id.includes(cortelliesapiIdValues[i])) {
-                    matchingValue = cortelliesapiIdValues[i];
-                    break;  // exit the loop if a match is found
-                }
-            }
-            if (matchingValue !== null){
-            let cortellisMainApi = req.app.portalGlobals.cortellisUi.cortelliesApi.cortelliesMainApiId;
-            let hasapikey = true;
-            if (hasapikey) {
+            let cortellisBundleApikey = null;
+    
+          
+            if (cortelliesOriginalApiId.length > 0) {
                 // loop will only excetue for JSON FILE API IDS only 
                 apps.forEach(app => {
                     if (app.swaggerLink && app.swaggerLink.includes(cortellisMainApi) && app.subscriptionApproved === true) {
                         if(app.apiKey !== "none")
-                        cortellisBundleApikey.push(app.apiKey)
+                        cortellisBundleApikey = app.apiKey;
                     }
                 });
               }
-            }
-            if (apiInfo.id === 'cortellies-api-collection' || apiInfo.id === "cortellis-api-collection"){
+            if (apiInfo.id === 'cortellies-api-collection' || apiInfo.id === cortellisMainApi){
                 let responseData;
                 let isAppSubscribed = apps.some(ele => ele.mayUnsubscribe && ele.mayUnsubscribe === true);
                 let subscribedIndex = apps.findIndex(ele=> ele.mayUnsubscribe && ele.mayUnsubscribe === true);

--- a/src/ui/views/api.pug
+++ b/src/ui/views/api.pug
@@ -151,9 +151,9 @@ block content
                     
                     if (apiIDs.some(innerArray => innerArray.includes(apiInfo.id))) 
                         if apiInfo.auth == "key-auth" && authUser && authUser.authenticated_scope.includes('wicked:api-cortellis-user') || authUser && authUser.admin && authUser.authenticated_scope.includes('wicked:api-cortellis-user') || authUser && authUser.superadmin && authUser.authenticated_scope.includes('wicked:api-cortellis-user')
-                            a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=none&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
+                            a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=${cortellisApiKey}&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
                         else if apiInfo.auth == "none" && authUser && authUser.authenticated_scope.includes('wicked:api-cortellis-user') 
-                            a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=none&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
+                            a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
                     //- HIDE swagger Button {"not logged in User} and {User not part of Cortellis Data Group}/        
                     else if !authUser || (apiInfo.auth == "none") && (authUser && !authUser.authenticated_scope.includes('wicked:api-cortellis-user') || authUser.authenticated_scope.includes('wicked:api-cortellis-user'))
                         a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=none&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;

--- a/src/ui/views/api.pug
+++ b/src/ui/views/api.pug
@@ -162,7 +162,7 @@ block content
                         a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
         
         if !authUser && apiInfo.auth != "none"
-            .panel.panel-danger
+            .panel.panel-danger.custom-hide
                 .panel-heading
                     h4.panel-title Not logged in
                 .panel-body

--- a/src/ui/views/api.pug
+++ b/src/ui/views/api.pug
@@ -151,7 +151,7 @@ block content
                     
                     if (apiIDs.some(innerArray => innerArray.includes(apiInfo.id))) 
                         if apiInfo.auth == "key-auth" && authUser && authUser.authenticated_scope.includes('wicked:api-cortellis-user') || authUser && authUser.admin && authUser.authenticated_scope.includes('wicked:api-cortellis-user') || authUser && authUser.superadmin && authUser.authenticated_scope.includes('wicked:api-cortellis-user')
-                            a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=${cortellisApiKey}&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
+                            a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=${CortellisApiKey}&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
                         else if apiInfo.auth == "none" && authUser && authUser.authenticated_scope.includes('wicked:api-cortellis-user') 
                             a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
                     //- HIDE swagger Button {"not logged in User} and {User not part of Cortellis Data Group}/        


### PR DESCRIPTION
### For Public user we have enabled the cortelllis api doc 

1. only api doc 
2. no swagger button no tryout column in application
3. not skus descriptions also.
### code changes 

1. with out customID skus wont be fetched when customId is not found it will throw error 
2. we check for customId undefined 
3. we are handling null exception in for getting skus data
### ### Enabling to tryout button for apis related cortellis UI in cortellis-api-collection

1. add in  async.parallel to get the subscriptions of cortellis-api-collection
2. pass the results while rendering the UI 
3. updateing apikey when auth key-auth for url of swagger doc button
4. when apikey in none , no apikey is passed 