### PR TITLE
Swagger rename "View Technical Documentation/ Swagger Definition" prod 

### DIFF
--- a/src/ui/views/api.pug
+++ b/src/ui/views/api.pug
@@ -131,9 +131,9 @@ block content
                 .panel-body
                     != apiDesc
                     if apiInfo.auth == "none"
-                        a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=none&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Swagger definition &raquo;
+                        a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?apikey=none&url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
                     else
-                        a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Swagger definition &raquo;
+                        a(href=`${glob.network.schema}://${glob.network.apiHost}/swagger-ui/?url=${encodeURIComponent(genericSwaggerUrl)}` role="button" target="_blank").btn.btn-default View Technical Documentation/ Swagger Definition &raquo;
         
         if !authUser && apiInfo.auth != "none"
             .panel.panel-danger


### PR DESCRIPTION
The button 'View Swagger Definition' is not intuitive for non-technical users.

THis can be renamed to 'View Technical Documentation/ Swagger Definition"

Move this to snapshot, stable and perf.

Lets target this to go to prod in release on the 15th of Feb.