### PR TITLE
changes SMP restrction for key-auth and approved subscription only one snapshot

### DIFF
--- a/src/ui/routes/admin.js
+++ b/src/ui/routes/admin.js
@@ -751,6 +751,7 @@ function getApiIdPlan(apiId, userId, req, res, next, callback) {
         let finalResult = [];
 
         if (userGroups.length > 0) {
+            //User part of Group
             for (let i = 0; i < allPlan.length; i++) {
                 const eachAllPlan = allPlan[i];
                 if (eachAllPlan && eachAllPlan.requiredGroup) {
@@ -774,8 +775,22 @@ function getApiIdPlan(apiId, userId, req, res, next, callback) {
                       };
                 });
             }
+            else {
+                //restriction for User Group which are not part of plan's required group
+                finalResult = allowRefinedPlan.map(apiPlan => {
+                    if (!apiPlan.requiredGroup) {
+                        return apiPlan;
+                      }
+                    return {
+                        ...apiPlan,
+                        this: apiPlan.requiredGroup,
+                        ...(apiPlan.requiredGroup ? {} : { this: 'hide' })
+                      };
+                });
+            }
         }
         else{
+            //If Public User or without any Group
             for (let i = 0; i < allPlan.length; i++) {
                 const eachAllPlan = allPlan[i];
                 if (eachAllPlan && eachAllPlan.requiredGroup) {

--- a/src/ui/views/manage_plans.pug
+++ b/src/ui/views/manage_plans.pug
@@ -64,8 +64,8 @@ block bodyScripts
 
         // Add click event to confirm plan button
         $popup.find('.btn-modify-plan').on('click', function() {
-            var selectedPlanInput = $popup.find('#ajaxInput').val(); 
-            $popup.find('#Note').show();// Get selected plan
+            var selectedPlanInput = $popup.find('#ajaxInput').val(); // Get selected plan
+            $popup.find('#Note').show();
             const requestBody = {
                 plan: selectedPlanInput,
                 apikey: apikey
@@ -104,7 +104,7 @@ block bodyScripts
                             '</div>' +
                             // Close button container
                             '<div style="text-align: center;">' +
-                            '<button class="btn btn-danger btn-close">Cancel</button>' +
+                            '<button class="btn btn-danger btn-close">Close</button>' +
                             '</div>' + // closing button container
                             '</div>' + // closing panel-body box-outline
                             '</div>' + // closing panel panel-default
@@ -191,7 +191,7 @@ block bodyScripts
               }).done(function(result) {
                 // Update items with empty api-group to "no group"
                 result.subscriptions.items.forEach(function(item) {
-                    if (!item['api_group']) {
+                    if (!item['api_group'] && item.auth === "key-auth" && item.approved === true) {
                         item['api_group'] = "no group";
                     }
                 });
@@ -282,9 +282,9 @@ block bodyScripts
 block content
     .jumbotron.wicked-admin-title
         .container.wicked-title-container
-            h1 All Subscriptions
+            h1 Modify Subscription Plans
 
-            p Index of all subscriptions in the API Portal.
+            p Please review the subscription plans
 
     .container.wicked-container
         br


### PR DESCRIPTION
### Add check for handling **_"if user is part of any of that group which are not part of plan's required Group"_**
**restrict plan modification which are part of required group.**

- renamed cancel button to close button.
- restriction for key-auth and approved subscription only one snapshot
- List of publicly visible API that are key based and with approved subscriptions only must be listed.
- Parent page should not reload when pop up opens
- When user clicks cancel on the pop-up , parent page must not reload.
- after user updates subscription plan and closes the pop-up, parent page can be refreshed and brought back to the same page number
