### PR TITLE
Implement a fix to handle the NullPointerException when invoking the entitlements endpoint for sku description [Stable]

### DIFF
--- a/src/ui/routes/apis.js
+++ b/src/ui/routes/apis.js
@@ -409,11 +409,13 @@ router.get('/:api', function (req, res, next) {
                             let values = []
                             response.data.entitlements.forEach(entitlement => {
                                 const entitelMentProduct = entitlement.entitlementProducts;
+                                if (entitelMentProduct) {
                                 Object.entries(entitelMentProduct).forEach(([key, value]) => {
                                     if(response.data.regular_skus.includes(key) && key.startsWith(contractedSkus)) {
                                         values.push(value);
                                     }
                                 });
+                                } 
                             });
                             responseData = values; 
                         }


### PR DESCRIPTION
It checks if entitelMentProduct is not any of the following falsy values: null, undefined, NaN, 0, "" (empty string), or false.