### PR TITLE
"handling missing fields in rate -limiting"

### DIFF
--- a/src/kickstarter/routes/pluginUtils.js
+++ b/src/kickstarter/routes/pluginUtils.js
@@ -146,7 +146,7 @@ function fixRateLimiting(data) {
         if (data.config.hasOwnProperty(prop) && data.config[prop] !== "")
             data.config[prop] = Number(data.config[prop]);
         else if (data.config.hasOwnProperty(prop))
-            delete data.config[prop];
+            data.config[prop]=null;
     }
     return data;
 }


### PR DESCRIPTION
In rate limiting, if any field is empty, it will be treated as null. If any field is null, it will allow unlimited requests