### PR TITLE
Add support for WOS application and custom headers in subscriptions snapshot

### DIFF
--- a/src/api/routes/subscriptions.js
+++ b/src/api/routes/subscriptions.js
@@ -440,6 +440,10 @@ subscriptions.addSubscription = function (app, res, applications, loggedInUserId
                 if (subsCreateInfo.api === "cortellis-api-collection" || subsCreateInfo.api === "cortelleis-api-collection"  ){
                     newSubscription.customId = userInfo.customId;
                 }
+                // If wos contracted header values are present, include in subscription
+                if(subsCreateInfo.woscontractedHeadervalues){
+                    newSubscription.woscontractedHeadervalues = subsCreateInfo.woscontractedHeadervalues;
+                }
                 dao.subscriptions.create(newSubscription, loggedInUserId, (err, persistedSubscription) => {
                     if (err) {
                         return utils.fail(res, 500, 'addSubscription: DAO create subscription failed', err);
@@ -496,6 +500,12 @@ subscriptions.addSubscription = function (app, res, applications, loggedInUserId
                                 name: apiPlan.name
                             }
                         };
+
+                        // If wos contracted header values are present, include in approval
+                        if(persistedSubscription.woscontractedHeadervalues){
+                            approvalInfo.user.woscontractedHeadervalues = persistedSubscription.woscontractedHeadervalues;
+                        }
+                
 
                         dao.approvals.create(approvalInfo, (err) => {
                             if (err) {

--- a/src/api/routes/utils.js
+++ b/src/api/routes/utils.js
@@ -303,12 +303,15 @@ utils.loadGlobals = function () {
     if (!_globalSettings) {
         const globalsFile = path.join(utils.getStaticDir(), 'globals.json');
         const cortelliesFile = path.join(utils.getStaticDir(), 'content','cortelliesUi','cortellisInfo.json');
+        const wosApplicationFile = path.join(utils.getStaticDir(), 'content','wos-application','application.json');
         _globalSettings = JSON.parse(fs.readFileSync(globalsFile, 'utf8'));
         let _cortellisUi = JSON.parse(fs.readFileSync(cortelliesFile, 'utf8'));
+        let _wosApp = JSON.parse(fs.readFileSync(wosApplicationFile, 'utf8'));
         utils.replaceEnvVars(_globalSettings);
         _globalSettings.configDate = getConfigDate();
         _globalSettings.lastCommit = getLastCommit();
         _globalSettings.cortellisUi = _cortellisUi;
+        _globalSettings.wosApp = _wosApp;
         // Return the used NODE_ENV, this is useful for debugging and error handling
         // when checking the configuration.
         _globalSettings.environment = process.env.NODE_ENV;

--- a/src/ui/routes/admin.js
+++ b/src/ui/routes/admin.js
@@ -95,8 +95,6 @@ router.post('/approvals/approve', function (req, res, next) {
 
 
                 if (subscribeResponse.statusCode === 200) {
-                    // Delay of 3 milliseconds before making the second request
-                    debug("mockbin request");
                     setTimeout(() => {
                         // Second call to http://localhost:3008/clarivate/api/customheaderss
                         const requestData = {
@@ -106,8 +104,6 @@ router.post('/approvals/approve', function (req, res, next) {
                             type: 'userLogin'
                         };
 
-                        debug("APPROVER CUSTOM HEADER");
-                        debug(JSON.stringify(requestData) + "approver custom header request data");
                         axios.post(`http://localhost:3008/clarivate/api/customheaders/${apiId}`, {}, {
                             headers: requestData
                         }).then(customHeaderResponse => {

--- a/src/ui/routes/admin.js
+++ b/src/ui/routes/admin.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const router = express.Router();
 const async = require('async');
+const axios = require('axios');
 const mustache = require('mustache');
 const { debug, info, warn, error } = require('portal-env').Logger('portal:admin');
 const tmp = require('tmp');

--- a/src/ui/routes/admin.js
+++ b/src/ui/routes/admin.js
@@ -67,10 +67,8 @@ router.post('/approvals/approve', function (req, res, next) {
     }
 
     utils.get(req, `/approvals/${approvalId}`, (err, apiRes, apiBody) => {
-        if (err)
-            return next(err);
+        if (err) return next(err);
         const approvalInfo = utils.getJson(apiBody);
-        debug(approvalInfo);
 
         if (approvalInfo.application.id !== appId)
             return next(utils.makeError(400, 'Bad request. Application ID does not match approval request.'));
@@ -82,20 +80,49 @@ router.post('/approvals/approve', function (req, res, next) {
             trusted: isTrusted
         };
 
-        // Hit the API
         utils.patch(req, `/applications/${appId}/subscriptions/${apiId}`, patchBody, (err, apiResponse, apiBody) => {
-            if (err)
-                return next(err);
-            if (200 != apiResponse.statusCode)
-                return utils.handleError(res, apiResponse, apiBody, next);
-            // Woohoo
-            if (!utils.acceptJson(req))
-                res.redirect('/admin/approvals');
-            else
-                res.json(utils.getJson(apiBody));
+            if (err) return next(err);
+            if (200 != apiResponse.statusCode) return utils.handleError(res, apiResponse, apiBody, next);
+            if (!utils.acceptJson(req)) res.redirect('/admin/approvals');
+            else res.json(utils.getJson(apiBody));
+
+
+            // If the API has wos custom headers, then we need to send a request to the Clarivate component to create custom headers for the user
+            if (apiBody.woscontractedHeadervalues) {
+                const useremail = approvalInfo.user.email;
+                const subscribeResponse = { statusCode: apiResponse.statusCode, data: apiBody.woscontractedHeadervalues };
+
+
+                if (subscribeResponse.statusCode === 200) {
+                    // Delay of 3 milliseconds before making the second request
+                    debug("mockbin request");
+                    setTimeout(() => {
+                        // Second call to http://localhost:3008/clarivate/api/customheaderss
+                        const requestData = {
+                            consumerId: appId + '$' + apiId,
+                            wosCustomHeader: subscribeResponse.data,
+                            'user-email': useremail,
+                            type: 'userLogin'
+                        };
+
+                        debug("APPROVER CUSTOM HEADER");
+                        debug(JSON.stringify(requestData) + "approver custom header request data");
+                        axios.post(`http://localhost:3008/clarivate/api/customheaders/${apiId}`, {}, {
+                            headers: requestData
+                        }).then(customHeaderResponse => {
+                            debug(`Custom Header Response ar: + approver custom header response`);
+                        }).catch(error => {
+                            debug(`Error fetching custom header: ${error.message}`);
+                        });
+                    }, 3); // 3 milliseconds delay
+                }
+            }
+            // End of custom header creation
         });
     });
 });
+
+
 
 router.post('/approvals/decline', function (req, res, next) {
     debug("post('/approvals/decline')");

--- a/src/ui/views/subscribe.pug
+++ b/src/ui/views/subscribe.pug
@@ -16,6 +16,20 @@ block scripts
         // Called from utils.js
         function localInit() {
             $('#trusted').on('change', checkTrust);
+
+            // Capture the selected use case values
+            $('input[name="useCase"]').on('change', function() {
+                var selectedUseCases = $('input[name="useCase"]:checked').map(function() {
+                    return $(this).val().replace(/\s+/g, '');
+                }).get();
+                $('#selectedUseCase').val(JSON.stringify(selectedUseCases));
+            });
+
+            // Ensure the selected plan is set before form submission
+            $('form').on('submit', function() {
+                var selectedPlan = $('input[name="plan"]:checked').val();
+                $('#selectedPlan').val(selectedPlan);
+            });
         }
 
 block content
@@ -28,7 +42,16 @@ block content
     .container.wicked-container
     
         h3 Application '#{application.name}'
-    
+        if isWosContractApi && apiPlans && apiPlans.length > 0
+            p Please specify the application for which you will be using this API key
+            .container-fluid.bkgrdf5f5f5
+                h4 Official Partners
+                each option, index in glob.wosApp.useCaseOptions
+                    div
+                        input(type='radio' name='useCase' id=`useCase_${index}` value=option.replace(/\s+/g, ''))
+                        span(style='margin-left: 5px;')
+                        label(for=`useCase_${index}` style='font-weight: normal;')= option 
+            br
         p.
             Specify which plan you want to subscribe to for the selected application.
        
@@ -41,12 +64,13 @@ block content
         if subscribeWarning
             .panel.panel-warning
                 .panel-heading
-                    h4.panel-title Warning
+                    h4.panel-title Warning  
                 .panel-body
                     p= subscribeWarning
 
         if allowSubscribe
-            form(role='form' action=`/applications/${application.id}/subscribe/${apiInfo.id}` method='post')
+            form(role='form' action=`/applications/${application.id}/globalSubscription/${apiInfo.id}` method='post')
+                input(type='hidden' id='selectedUseCase' name='selectedUseCase' value='')
                 if apiPlans && apiPlans.length > 0
 
                     if apiInfo.auth == 'oauth2'
@@ -63,7 +87,7 @@ block content
                                     label(for="trusted").form-check-label &nbsp;Trust this application
                     else
                         input(type='hidden' name='trusted' id='trusted' value='')
-
+                    
                     table(class='table table-striped')
                         thead
                             tr
@@ -75,8 +99,10 @@ block content
                         tbody
                             each plan, index in apiPlans
                                 tr
-                                    td
-                                        if index == 0
+                                    td 
+                                        if isWosContractApi
+                                            input(type='radio' name='plan' value=plan.id required)
+                                        else if index == 0
                                             input(type='radio' name='plan' value=plan.id checked='checked')
                                         else
                                             input(type='radio' name='plan' value=plan.id)


### PR DESCRIPTION
### Backend:

1. Extracting WoS APIs and WoS custom headers from application.json in the Wicked configuration.
2. Temporarily including WoS custom header data in subscription and approval data. Once approved, it will be deleted based on specific conditions.

### Frontend Service:

1. Adding an option to select custom headers for certain WoS APIs.
2. admin.js to handle user-level creation of custom headers.
3. application.js to handle admin-level creation of custom headers.