### PR TITLE
fix: remove size parameter from paging URL in kongPagingGet function

### DIFF
--- a/src/kong-adapter/src/kong/utils.ts
+++ b/src/kong-adapter/src/kong/utils.ts
@@ -319,11 +319,7 @@ function kongGet(url: string, callback: Callback<any>) {
 
 function kongPagingGet(url: string, callback: Callback<any>) {
     let pagingUrl;
-    const size = 1000;
-    if (url.indexOf('?') > 0)
-        pagingUrl = `${url}&size=${size}`;
-    else
-        pagingUrl = `${url}?size=${size}`;
+    pagingUrl = url;
     console.log(pagingUrl);
     const dataArray = [];
     let finished = false;


### PR DESCRIPTION
## Summary

**In a Nutshell**

This PR includes changes made to support the Kong 3.9 upgrade in the Kong Adapter. As part of the fix, the kongPagingGet function was refactored to simplify URL handling by removing the logic that automatically appends the size=1000 query parameter and passing the URL through unchanged. This consolidates URL parameter handling, reduces code complexity, and resolves the issue observed during the Kong 3.9 upgrade.
---

## PR Details

| Attribute | Value |
|-----------|-------|
| **Title** | Refactor kongPagingGet to simplify URL handling by removing size parameter |
| **Author** | darshan-clvt |
| **State** | ✅ Merged |
| **Merged At** | 2026-07-01 11:49:45 UTC |
| **Base Branch** | `route_level_plugin` |
| **Head Branch** | `kong3.9-post-upgrade-stable` |
| **Commits** | 1 |
| **Files Changed** | 1 |
| **Lines Added/Deleted** | +1 / -5 |
| **Comments** | 0 |
| **Reviews** | 0 (no review comments) |
| **Draft** | No |

---

## Changes Made

**File**: `src/kong-adapter/src/kong/utils.ts`

The refactor removes the hardcoded `size` parameter logic from the `kongPagingGet` function:

- **Removed**: 4 lines of conditional logic that handled appending `?size=1000` or `&size=1000` depending on whether the URL already contained query parameters
- **Replaced with**: A single assignment `pagingUrl = url;`

This implies that pagination size handling is now either:
- Handled externally (by callers passing the size parameter)
- Managed through a different mechanism
- No longer needed for this specific API interaction

---

## Risk Assessment

**Low risk** — The change is minimal and surgical (5 lines deleted, 1 line added). aligns with Kong 3.9 API expectations 